### PR TITLE
Remove increment and decrement operators

### DIFF
--- a/Sources/Mustache/Goodies/Logger.swift
+++ b/Sources/Mustache/Goodies/Logger.swift
@@ -76,13 +76,13 @@ extension StandardLibrary {
                 willRender: { (tag, box) in
                     if tag.type == .Section {
                         self.log("\(self.indentationPrefix)\(tag) will render \(box.valueDescription)")
-                        self.indentationLevel++
+                        self.indentationLevel += 1
                     }
                     return box
                 },
                 didRender: { (tag, box, string) in
                     if tag.type == .Section {
-                        self.indentationLevel--
+                        self.indentationLevel -= 1
                     }
                     if let string = string {
                         self.log("\(self.indentationPrefix)\(tag) did render \(box.valueDescription) as \(string.debugDescription)")

--- a/Sources/Mustache/Parsing/TemplateParser.swift
+++ b/Sources/Mustache/Parsing/TemplateParser.swift
@@ -72,7 +72,7 @@ final class TemplateParser {
             case .Start:
                 if c == "\n" {
                     state = .Text(startIndex: i, startLineNumber: lineNumber)
-                    ++lineNumber
+                    lineNumber += 1
                 } else if atString(i, currentDelimiters.unescapedTagStart) {
                     state = .UnescapedTag(startIndex: i, startLineNumber: lineNumber)
                     i = i.advancedBy(currentDelimiters.unescapedTagStartLength).predecessor()
@@ -87,7 +87,7 @@ final class TemplateParser {
                 }
             case .Text(let startIndex, let startLineNumber):
                 if c == "\n" {
-                    ++lineNumber
+                    lineNumber += 1
                 } else if atString(i, currentDelimiters.unescapedTagStart) {
                     if startIndex != i {
                         let range = startIndex..<i
@@ -136,7 +136,7 @@ final class TemplateParser {
                 }
             case .Tag(let startIndex, let startLineNumber):
                 if c == "\n" {
-                    ++lineNumber
+                    lineNumber += 1
                 } else if atString(i, currentDelimiters.tagDelimiterPair.1) {
                     let tagInitialIndex = startIndex.advancedBy(currentDelimiters.tagStartLength)
                     let tagInitial = templateString[tagInitialIndex]
@@ -258,7 +258,7 @@ final class TemplateParser {
                 break
             case .UnescapedTag(let startIndex, let startLineNumber):
                 if c == "\n" {
-                    ++lineNumber
+                    lineNumber += 1
                 } else if atString(i, currentDelimiters.unescapedTagEnd) {
                     let tagInitialIndex = startIndex.advancedBy(currentDelimiters.unescapedTagStartLength)
                     let content = templateString.substringWithRange(tagInitialIndex..<i)
@@ -276,7 +276,7 @@ final class TemplateParser {
                 }
             case .SetDelimitersTag(let startIndex, let startLineNumber):
                 if c == "\n" {
-                    ++lineNumber
+                    lineNumber += 1
                 } else if atString(i, currentDelimiters.setDelimitersEnd) {
                     let tagInitialIndex = startIndex.advancedBy(currentDelimiters.setDelimitersStartLength)
                     let content = templateString.substringWithRange(tagInitialIndex..<i)


### PR DESCRIPTION
These will be removed in Swift 3 and cause warnings in Swift 2.2.
